### PR TITLE
fix create-compute-appendix

### DIFF
--- a/experiment_impact_tracker/utils.py
+++ b/experiment_impact_tracker/utils.py
@@ -147,7 +147,6 @@ def gather_additional_info(info, logdir):
         else None
     )
 
-    total_power_per_timestep = None
     if has_gpu and (kw_hr_rapl is not None):
         total_power_per_timestep = PUE * (kw_hr_nvidia + kw_hr_rapl)
     elif kw_hr_rapl is not None:
@@ -181,16 +180,16 @@ def gather_additional_info(info, logdir):
         try:
             estimated_carbon_impact_grams_per_timestep = (
                 np.multiply(total_power_per_timestep, realtime_carbon)
-                if total_power_per_timestep
-                else None
+                if not total_power_per_timestep.empty
+                else pd.DataFrame()
             )
-        except:
-            import pdb; pdb.set_trace()
+        except :
+            log.exception('')
 
         estimated_carbon_impact_grams = (
             estimated_carbon_impact_grams_per_timestep.sum()
-            if estimated_carbon_impact_grams_per_timestep
-            else None
+            if not estimated_carbon_impact_grams_per_timestep.empty
+            else pd.DataFrame()
         )
     else:
         if total_power is not None:

--- a/scripts/create-compute-appendix
+++ b/scripts/create-compute-appendix
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import json
 import os
@@ -28,6 +26,7 @@ from experiment_impact_tracker.emissions.get_region_metrics import \
 from experiment_impact_tracker.utils import gather_additional_info
 
 pd.set_option('display.max_colwidth', -1)
+
 
 def _gather_executive_summary(aggregated_info, executive_summary_variables, experiment_set_names, all_points=False):
     # Gather variables to generate executive summary for
@@ -211,7 +210,6 @@ def _aggregated_data_for_filterset(output_dir,
 
                 # {k: [v] for k, v in info["gpu_info"].items()})
                 if "gpu_info" in info:
-                    import pdb;pdb.set_trace()
                     gpu_data_frame = pd.DataFrame.from_dict(info["gpu_info"])
                     gpu_infos_all[experiment_set_names[exp_set]].append(
                         gpu_data_frame)
@@ -283,7 +281,7 @@ def _create_leaf_page(output_directory, all_infos, exp_set_name, description, ex
             data_zip_paths_all[exp_set_name][i], html_output_dir)
 
         template_args = {}
-        if gpu_infos_all and gpu_infos_all[exp_set_name] and gpu_infos_all[exp_set_name][i]:
+        if len(gpu_infos_all) > 0 and len(gpu_infos_all[exp_set_name]) > 0 and not gpu_infos_all[exp_set_name][i].empty:
             template_args["gpu_info"] = gpu_infos_all[exp_set_name][i].T
 
         template_args["exp_set_names_titles"] = [(_format_setname(experiment_set_names[exp_set]), experiment_set_names[exp_set])


### PR DESCRIPTION
Address https://github.com/Breakend/experiment-impact-tracker/issues/39

I was able to reproduce the issue, but basically the tl;dr is we can not check if a dataframe is empty by `if dataframe` but instead do something like `if not dataframe.empty`
```
Traceback (most recent call last):
  File "/usr/local/anaconda3/envs/test-j/bin/create-compute-appendix", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/jieruhu/workspace/experiment-impact-tracker/scripts/create-compute-appendix", line 429, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/Users/jieruhu/workspace/experiment-impact-tracker/scripts/create-compute-appendix", line 425, in main
    _recursive_create(all_log_dirs, args.output_dir, site_spec)
  File "/Users/jieruhu/workspace/experiment-impact-tracker/scripts/create-compute-appendix", line 362, in _recursive_create
    _recursive_create(filtered_dirs, new_output_dir,
  File "/Users/jieruhu/workspace/experiment-impact-tracker/scripts/create-compute-appendix", line 362, in _recursive_create
    _recursive_create(filtered_dirs, new_output_dir,
  File "/Users/jieruhu/workspace/experiment-impact-tracker/scripts/create-compute-appendix", line 381, in _recursive_create
    _create_leaf_page(output_directory, all_infos, experiment_set, values["description"],
  File "/Users/jieruhu/workspace/experiment-impact-tracker/scripts/create-compute-appendix", line 284, in _create_leaf_page
    if gpu_infos_all and gpu_infos_all[exp_set_name] and gpu_infos_all[exp_set_name][i]:
  File "/usr/local/anaconda3/envs/test-j/lib/python3.8/site-packages/pandas/core/generic.py", line 1439, in __nonzero__
    raise ValueError(
ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

testing:

run the script on experiment results from `ClimateChangeFromMachineLearningResearch` and verify the doc is created correctly
```
$ create-compute-appendix $RESULTS/experiment_results --site_spec $RESULTS/appendix_website_definitions/website_defs.json --output_dir ./docs/
```
