### PR TITLE
Location override feature

### DIFF
--- a/examples/my_experiment.py
+++ b/examples/my_experiment.py
@@ -51,7 +51,7 @@ class Experiment:
 def my_experiment(region_coords=None) -> None:
     tmp_dir = tempfile.mkdtemp()
     # Init tracker with log path
-    tracker = ImpactTracker(tmp_dir,REGION_COORDS)
+    tracker = ImpactTracker(tmp_dir,region_coords)
     # Start tracker in a separate process
     tracker.launch_impact_monitor()
 
@@ -74,6 +74,5 @@ if __name__ == "__main__":
 
     # Example latitude and longitude by city
     # MTL:(45.4972159,-73.6103642), NYC:(40.741895,-73.989308), Pune:(18.521428,73.8544541), Paris:(48.8566969,2.3514616)
-    
     REGION_COORDS =  (45.4972159,-73.6103642)  
     my_experiment(REGION_COORDS)

--- a/examples/my_experiment.py
+++ b/examples/my_experiment.py
@@ -1,6 +1,7 @@
 import sys
 import tempfile
-
+sys.path.append('../')
+sys.path.append('./')
 import torch
 
 from experiment_impact_tracker.compute_tracker import ImpactTracker
@@ -47,16 +48,19 @@ class Experiment:
         self.w2 -= self.learning_rate * grad_w2
 
 
-def my_experiment() -> None:
+def my_experiment(REGION_COORDS=None) -> None:
     tmp_dir = tempfile.mkdtemp()
     # Init tracker with log path
-    tracker = ImpactTracker(tmp_dir)
+    tracker = ImpactTracker(tmp_dir,REGION_COORDS)
     # Start tracker in a separate process
     tracker.launch_impact_monitor()
 
+    print(tracker.initial_info['region'])
+    print('')
+    print(tracker.initial_info['region_carbon_intensity_estimate'])
     exp = Experiment()
 
-    for t in range(100):
+    for t in range(10):
         if t % 10 == 9:
             print(f"Pass: {t}")
             # Optional. Adding this will ensure that your experiment stops if impact tracker throws an exception and exit.
@@ -67,4 +71,5 @@ def my_experiment() -> None:
 
 
 if __name__ == "__main__":
-    my_experiment()
+    REGION_COORDS =  (45.4972159,-73.6103642)  #MTL:(45.4972159,-73.6103642), NYC:(40.741895,-73.989308), Pune:(18.521428,73.8544541), Paris:(48.8566969,2.3514616)
+    my_experiment(REGION_COORDS)

--- a/examples/my_experiment.py
+++ b/examples/my_experiment.py
@@ -48,7 +48,7 @@ class Experiment:
         self.w2 -= self.learning_rate * grad_w2
 
 
-def my_experiment(REGION_COORDS=None) -> None:
+def my_experiment(region_coords=None) -> None:
     tmp_dir = tempfile.mkdtemp()
     # Init tracker with log path
     tracker = ImpactTracker(tmp_dir,REGION_COORDS)
@@ -60,7 +60,7 @@ def my_experiment(REGION_COORDS=None) -> None:
     print(tracker.initial_info['region_carbon_intensity_estimate'])
     exp = Experiment()
 
-    for t in range(10):
+    for t in range(100):
         if t % 10 == 9:
             print(f"Pass: {t}")
             # Optional. Adding this will ensure that your experiment stops if impact tracker throws an exception and exit.
@@ -71,5 +71,9 @@ def my_experiment(REGION_COORDS=None) -> None:
 
 
 if __name__ == "__main__":
-    REGION_COORDS =  (45.4972159,-73.6103642)  #MTL:(45.4972159,-73.6103642), NYC:(40.741895,-73.989308), Pune:(18.521428,73.8544541), Paris:(48.8566969,2.3514616)
+
+    # Example latitude and longitude by city
+    # MTL:(45.4972159,-73.6103642), NYC:(40.741895,-73.989308), Pune:(18.521428,73.8544541), Paris:(48.8566969,2.3514616)
+    
+    REGION_COORDS =  (45.4972159,-73.6103642)  
     my_experiment(REGION_COORDS)

--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -75,7 +75,7 @@ def read_latest_stats(log_dir):
     return None
 
 
-def _sample_and_log_power(log_dir, REGION_COORDS, initial_info, logger=None):
+def _sample_and_log_power(log_dir, region_coords, initial_info, logger=None):
     """
     Iterates over compatible metrics and logs the relevant information.
 
@@ -93,7 +93,7 @@ def _sample_and_log_power(log_dir, REGION_COORDS, initial_info, logger=None):
     )  # dedupe so that we don't double count by accident
 
     #required_headers = _get_compatible_data_headers(get_current_region_info_cached()[0])
-    required_headers = _get_compatible_data_headers(get_region_info(REGION_COORDS)[0])
+    required_headers = _get_compatible_data_headers(get_region_info(region_coords)[0])
 
     header_information = {}
 
@@ -138,7 +138,7 @@ def _sample_and_log_power(log_dir, REGION_COORDS, initial_info, logger=None):
 
 
 @processify
-def launch_power_monitor(queue, log_dir, REGION_COORDS, initial_info, logger=None):
+def launch_power_monitor(queue, log_dir, region_coords, initial_info, logger=None):
     """
     Launches a separate process which monitors metrics
 
@@ -161,7 +161,7 @@ def launch_power_monitor(queue, log_dir, REGION_COORDS, initial_info, logger=Non
             pass
 
         try:
-            _sample_and_log_power(log_dir, REGION_COORDS, initial_info, logger=logger)
+            _sample_and_log_power(log_dir, region_coords, initial_info, logger=logger)
         except:
             ex_type, ex_value, tb = sys.exc_info()
             logger.error("Encountered exception within power monitor thread!")
@@ -207,7 +207,7 @@ def _validate_compatabilities(compatabilities, *args, **kwargs):
     return True
 
 
-def gather_initial_info(log_dir: str, REGION_COORDS=None): 
+def gather_initial_info(log_dir: str, region_coords=None): 
     """Log one time info
 
     For example, CPU/GPU info, version of this package, region, datetime for start of experiment,
@@ -221,8 +221,8 @@ def gather_initial_info(log_dir: str, REGION_COORDS=None):
 
     data = {}
     
-    print('Region coords: {}'.format(REGION_COORDS))
-    INITIAL_INFO = get_initial_info(REGION_COORDS) 
+    print('Region coords: {}'.format(region_coords))
+    INITIAL_INFO = get_initial_info(region_coords) 
     
     # Gather all the one-time info specified by the appropriate router
     for info_ in INITIAL_INFO:

--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -22,8 +22,10 @@ from pandas.io.json import json_normalize
 from experiment_impact_tracker.cpu import rapl
 from experiment_impact_tracker.cpu.common import get_my_cpu_info
 from experiment_impact_tracker.cpu.intel import get_intel_power, get_rapl_power
-from experiment_impact_tracker.data_info_and_router import (DATA_HEADERS,
-                                                            INITIAL_INFO)
+# from experiment_impact_tracker.data_info_and_router import (DATA_HEADERS,
+#                                                             INITIAL_INFO)
+#import wrapper for DATA_HEADERS, INITIAL_INFO
+from experiment_impact_tracker.data_info_and_router import get_initial_info, get_data_headers
 from experiment_impact_tracker.data_utils import *
 from experiment_impact_tracker.emissions.common import \
     is_capable_realtime_carbon_intensity
@@ -175,6 +177,7 @@ def _get_compatible_data_headers(region=None):
     :return: which headers are compatible
     """
     compatible_headers = []
+    DATA_HEADERS = get_data_headers()
 
     for header in DATA_HEADERS:
         compat = True
@@ -203,7 +206,7 @@ def _validate_compatabilities(compatabilities, *args, **kwargs):
     return True
 
 
-def gather_initial_info(log_dir: str):
+def gather_initial_info(log_dir: str, REGION_COORDS=None): 
     """Log one time info
 
     For example, CPU/GPU info, version of this package, region, datetime for start of experiment,
@@ -217,6 +220,7 @@ def gather_initial_info(log_dir: str):
 
     data = {}
 
+    INITIAL_INFO = get_initial_info(REGION_COORDS) 
     # Gather all the one-time info specified by the appropriate router
     for info_ in INITIAL_INFO:
         key = info_["name"]
@@ -239,11 +243,11 @@ def gather_initial_info(log_dir: str):
 
 
 class ImpactTracker(object):
-    def __init__(self, logdir):
+    def __init__(self, logdir, REGION_COORDS=None):
         self.logdir = logdir
         self._setup_logging()
         self.logger.info("Gathering system info for reproducibility...")
-        self.initial_info = gather_initial_info(logdir)
+        self.initial_info = gather_initial_info(logdir, REGION_COORDS)
         self.logger.info("Done initial setup and information gathering...")
         self.launched = False
 

--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -22,10 +22,10 @@ from pandas.io.json import json_normalize
 from experiment_impact_tracker.cpu import rapl
 from experiment_impact_tracker.cpu.common import get_my_cpu_info
 from experiment_impact_tracker.cpu.intel import get_intel_power, get_rapl_power
-# from experiment_impact_tracker.data_info_and_router import (DATA_HEADERS,
-#                                                             INITIAL_INFO)
+
 #import wrapper for DATA_HEADERS, INITIAL_INFO
 from experiment_impact_tracker.data_info_and_router import get_initial_info, get_data_headers
+
 from experiment_impact_tracker.data_utils import *
 from experiment_impact_tracker.emissions.common import \
     is_capable_realtime_carbon_intensity
@@ -246,12 +246,12 @@ def gather_initial_info(log_dir: str, REGION_COORDS=None):
 
 
 class ImpactTracker(object):
-    def __init__(self, logdir, REGION_COORDS=None):
+    def __init__(self, logdir, region_coords=None):
         self.logdir = logdir
-        self.region_coords = REGION_COORDS
+        self.region_coords = region_coords
         self._setup_logging()
         self.logger.info("Gathering system info for reproducibility...")
-        self.initial_info = gather_initial_info(logdir, REGION_COORDS)
+        self.initial_info = gather_initial_info(logdir, region_coords)
         self.logger.info("Done initial setup and information gathering...")
         self.launched = False
 

--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -30,7 +30,7 @@ from experiment_impact_tracker.data_utils import *
 from experiment_impact_tracker.emissions.common import \
     is_capable_realtime_carbon_intensity
 from experiment_impact_tracker.emissions.get_region_metrics import \
-    get_current_region_info_cached
+    get_current_region_info_cached, get_region_info
 from experiment_impact_tracker.gpu.nvidia import (get_gpu_info,
                                                   get_nvidia_gpu_power)
 from experiment_impact_tracker.utils import (get_timestamp, processify,
@@ -75,7 +75,7 @@ def read_latest_stats(log_dir):
     return None
 
 
-def _sample_and_log_power(log_dir, initial_info, logger=None):
+def _sample_and_log_power(log_dir, REGION_COORDS, initial_info, logger=None):
     """
     Iterates over compatible metrics and logs the relevant information.
 
@@ -92,7 +92,8 @@ def _sample_and_log_power(log_dir, initial_info, logger=None):
         set(process_ids)
     )  # dedupe so that we don't double count by accident
 
-    required_headers = _get_compatible_data_headers(get_current_region_info_cached()[0])
+    #required_headers = _get_compatible_data_headers(get_current_region_info_cached()[0])
+    required_headers = _get_compatible_data_headers(get_region_info(REGION_COORDS)[0])
 
     header_information = {}
 
@@ -137,7 +138,7 @@ def _sample_and_log_power(log_dir, initial_info, logger=None):
 
 
 @processify
-def launch_power_monitor(queue, log_dir, initial_info, logger=None):
+def launch_power_monitor(queue, log_dir, REGION_COORDS, initial_info, logger=None):
     """
     Launches a separate process which monitors metrics
 
@@ -160,7 +161,7 @@ def launch_power_monitor(queue, log_dir, initial_info, logger=None):
             pass
 
         try:
-            _sample_and_log_power(log_dir, initial_info, logger=logger)
+            _sample_and_log_power(log_dir, REGION_COORDS, initial_info, logger=logger)
         except:
             ex_type, ex_value, tb = sys.exc_info()
             logger.error("Encountered exception within power monitor thread!")
@@ -219,8 +220,10 @@ def gather_initial_info(log_dir: str, REGION_COORDS=None):
     info_path = safe_file_path(os.path.join(log_dir, INFOPATH))
 
     data = {}
-
+    
+    print('Region coords: {}'.format(REGION_COORDS))
     INITIAL_INFO = get_initial_info(REGION_COORDS) 
+    
     # Gather all the one-time info specified by the appropriate router
     for info_ in INITIAL_INFO:
         key = info_["name"]
@@ -245,6 +248,7 @@ def gather_initial_info(log_dir: str, REGION_COORDS=None):
 class ImpactTracker(object):
     def __init__(self, logdir, REGION_COORDS=None):
         self.logdir = logdir
+        self.region_coords = REGION_COORDS
         self._setup_logging()
         self.logger.info("Gathering system info for reproducibility...")
         self.initial_info = gather_initial_info(logdir, REGION_COORDS)
@@ -296,7 +300,7 @@ class ImpactTracker(object):
             # OS X multiprocessing starts processes with spawn instead of fork
             multiprocessing.set_start_method("fork")
             self.p, self.queue = launch_power_monitor(
-                self.logdir, self.initial_info, self.logger
+                self.logdir, self.region_coords, self.initial_info, self.logger
             )
 
             def _terminate_monitor_and_log_final_info(p):

--- a/experiment_impact_tracker/cpu/intel.py
+++ b/experiment_impact_tracker/cpu/intel.py
@@ -151,6 +151,7 @@ def get_powercap_power(pid_list, logger=None, **kwargs):
             zombies.append(i)
 
     time.sleep(2.0)
+    
 
     for p in process_list:
         st21 = _timer()
@@ -355,6 +356,7 @@ def get_rapl_power(pid_list, logger=None, **kwargs):
         # Modifying code https://github.com/giampaolo/psutil/blob/c10df5aa04e1ced58d19501fa42f08c1b909b83d/psutil/__init__.py#L1102-L1107
         # We want relative percentage of CPU used so we ignore the multiplier by number of CPUs, we want a number from 0-1.0 to give
         # power credits accordingly
+
         st11 = _timer()
         # units in terms of cpu-time, so we need the cpu in the last time period that are for the process only
         system_wide_pt1 = psutil.cpu_times()
@@ -363,11 +365,13 @@ def get_rapl_power(pid_list, logger=None, **kwargs):
             pt1 = p.cpu_times()
             infos1.append((st11, st12, system_wide_pt1, pt1))
         except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            infos1.append(None) # Maintain the length equal to process_list to avoid index mismatch during power sampling.
             zombies.append(i)
 
     time.sleep(2.0)
 
-    for p in process_list:
+    # Added enumerater "i" to keep track of zombie processes.
+    for i, p in enumerate(process_list):
         st21 = _timer()
         try:
             pt2 = p.cpu_times()
@@ -375,8 +379,9 @@ def get_rapl_power(pid_list, logger=None, **kwargs):
             system_wide_pt2 = psutil.cpu_times()
             infos2.append((st21, st22, system_wide_pt2, pt2))
         except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            infos2.append(None) # Maintain the length equal to process_list to avoid index mismatch during power sampling.
             zombies.append(i)
-
+    
     # now is a good time to get the power samples that we got the process times for
     s2 = rapl.RAPLMonitor.sample()
     diff = s2 - s1
@@ -427,7 +432,8 @@ def get_rapl_power(pid_list, logger=None, **kwargs):
     if total_gpu_power != 0:
         raise ValueError("Don't support credit assignment to Intel RAPL GPU yet.")
 
-    for i, p in enumerate(process_list):
+    for i, p in enumerate(process_list): 
+        # Ignore calculations for the zombie processes. They are denoted as None in the infos lists.
         if i in zombies:
             continue
 

--- a/experiment_impact_tracker/cpu/intel.py
+++ b/experiment_impact_tracker/cpu/intel.py
@@ -148,12 +148,13 @@ def get_powercap_power(pid_list, logger=None, **kwargs):
             pt1 = p.cpu_times()
             infos1.append((st11, st12, system_wide_pt1, pt1))
         except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            infos1.append(None) # Maintain the length equal to process_list to avoid index mismatch during power sampling.
             zombies.append(i)
 
     time.sleep(2.0)
-    
 
-    for p in process_list:
+    # for p in process_list:
+    for i, p in enumerate(process_list):
         st21 = _timer()
         try:
             pt2 = p.cpu_times()
@@ -161,7 +162,9 @@ def get_powercap_power(pid_list, logger=None, **kwargs):
             system_wide_pt2 = psutil.cpu_times()
             infos2.append((st21, st22, system_wide_pt2, pt2))
         except (psutil.NoSuchProcess, psutil.ZombieProcess):
+            infos2.append(None) # Maintain the length equal to process_list to avoid index mismatch during power sampling.
             zombies.append(i)
+
     # now is a good time to get the power samples that we got the process times for
     powercap_results = powercap_interface.join()
     total_intel_power = powercap_results.get("Processor Power_0(Watt)", 0)
@@ -173,6 +176,7 @@ def get_powercap_power(pid_list, logger=None, **kwargs):
         raise ValueError("Don't support credit assignment to Intel RAPL GPU yet.")
 
     for i, p in enumerate(process_list):
+        # Ignore calculations for the zombie processes. They are denoted as None in the infos lists.
         if i in zombies:
             continue
         st1, st12, system_wide_pt1, pt1 = infos1[i]

--- a/experiment_impact_tracker/data_info_and_router.py
+++ b/experiment_impact_tracker/data_info_and_router.py
@@ -12,7 +12,7 @@ from experiment_impact_tracker.disk.common import measure_disk_speed_at_dir
 from experiment_impact_tracker.emissions.common import (
     get_realtime_carbon, is_capable_realtime_carbon_intensity)
 from experiment_impact_tracker.emissions.get_region_metrics import \
-    get_current_region_info_cached
+    get_current_region_info_cached, get_region_info
 from experiment_impact_tracker.gpu.nvidia import (get_gpu_info,
                                                   get_nvidia_gpu_power,
                                                   is_nvidia_compatible)
@@ -25,158 +25,172 @@ get_version_number = lambda *args, **kwargs: experiment_impact_tracker.__version
 get_time_now = lambda *args, **kwargs: datetime.now()
 all_compatible = lambda *args, **kwargs: True
 
-INITIAL_INFO = [
-    {
-        "name": "python_package_info",
-        "description": "Python package info.",
-        "compatability": [all_compatible],
-        "routing": {"function": get_python_packages_and_versions},
-    },
-    {
-        "name": "cpu_info",
-        "description": "CPU hardware information.",
-        "compatability": [all_compatible],
-        "routing": {"function": get_my_cpu_info},
-    },
-    {
-        "name": "experiment_start",
-        "description": "Start time of experiment.",
-        "compatability": [all_compatible],
-        "routing": {"function": get_time_now},
-    },
-    {
-        "name": "gpu_info",
-        "description": "GPU hardware information.",
-        "compatability": [is_nvidia_compatible, is_linux],
-        "routing": {"function": get_gpu_info},
-    },
-    {
-        "name": "experiment_impact_tracker_version",
-        "description": "Version of experiment-impact-tracker framework.",
-        "compatability": [all_compatible],
-        "routing": {"function": get_version_number},
-    },
-    {
-        "name": "region",
-        "description": "The region we determine this experiment to be run in.",
-        "compatability": [all_compatible],
-        "routing": {"function": lambda: get_current_region_info_cached()[0]},
-    },
-    {
-        "name": "region_carbon_intensity_estimate",
-        "description": "The average carbon intensity estimated for the region this experiment is in.",
-        "compatability": [all_compatible],
-        "routing": {"function": lambda: get_current_region_info_cached()[1]},
-    },
-]
+# Replaced INITIAL_INFO AND DATA_HEADERS with a function wrapper
+def get_initial_info(REGION_COORDS=None): 
 
-DATA_HEADERS = [
-    {
-        "name": "timestamp",
-        "description": "Time at which sample was drawn based on local machine time in timestamp format.",
-        "compatability": [all_compatible],
-        "routing": {"function": get_timestamp},
-    },
-    {
-        "name": "rapl_power_draw_absolute",
-        "description": "The absolute power draw reading read from an Intel RAPL package. This is in terms of Watts across the entire machine.",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "rapl_estimated_attributable_power_draw",
-        "description": "This is the estimated attributable power draw to this process and all child processes based on power draw reading read from an Intel RAPL package. This is calculated as (watts used by cpu) * (relative cpu percentage used) + (watts used by dram) * (relative dram percentage used) + (watts used by other package elements) * (relative cpu percentage used).",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "nvidia_draw_absolute",
-        "description": "This is the absolute power draw of all accessible NVIDIA GPUs on the system (as long as the main process or any child process lives on the GPU). Calculated as sum across all GPUs.",
-        "compatability": [is_nvidia_compatible, is_linux],
-        "routing": {"function": get_nvidia_gpu_power},
-    },
-    {
-        "name": "nvidia_estimated_attributable_power_draw",
-        "description": "This is the estimated attributable power draw of all accessible NVIDIA GPUs on the system (as long as the main process or any child process lives on the GPU). Calculated as the sum per gpu of (absolute power draw per gpu) * (relative process percent utilization of gpu)",
-        "compatability": [is_nvidia_compatible, is_linux],
-        "routing": {"function": get_nvidia_gpu_power},
-    },
-    {
-        "name": "cpu_time_seconds",
-        "description": "This is the total CPU time used so far by the program in seconds.",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "average_gpu_estimated_utilization_absolute",
-        "description": "This is the absolute utilization of the GPUs by the main process and all child processes. Returns an average result across several trials of nvidia-smi pmon -c 10. Averaged across GPUs. Using .05 to indicate 5%.",
-        "compatability": [is_nvidia_compatible, is_linux],
-        "routing": {"function": get_nvidia_gpu_power},
-    },
-    {
-        "name": "average_gpu_estimated_utilization_relative",
-        "description": "This is the relative utilization of the GPUs by the main process and all child processes. Returns an average result across several trials of nvidia-smi pmon -c 10 and the percentage that this process and all child process utilize for the gpu.  Averaged across GPUs. Using .05 to indicate 5%. ",
-        "compatability": [is_nvidia_compatible, is_linux],
-        "routing": {"function": get_nvidia_gpu_power},
-    },
-    {
-        "name": "average_relative_cpu_utilization",
-        "description": "This is the relative CPU utlization compared to the utilization of the whole system at that time. E.g., if the total system is using 50\% of the CPU power, but our program is only using 25\%, this will return .5.",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "absolute_cpu_utilization",
-        "description": "This is the relative CPU utlization compared to the utilization of the whole system at that time. E.g., if the total system is using 50\% of 4 CPUs, but our program is only using 25\% of 2 CPUs, this will return .5 (same as in top). There is no multiplier times the number of cores in this case as top does. ",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "per_gpu_performance_state",
-        "description": "A concatenated string which gives the performance state of every single GPU used by the main process or all child processes. Example formatting looks like <gpuid>::<performance state>. E.g., 0::P0",
-        "compatability": [is_nvidia_compatible, is_linux],
-        "routing": {"function": get_nvidia_gpu_power},
-    },
-    {
-        "name": "relative_mem_usage",
-        "description": "The percentage of all in-use ram this program is using.",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "absolute_mem_usage",
-        "description": "The amount of memory being used.",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "absolute_mem_percent_usage",
-        "description": "The amount of memory being used as an absolute percentage of total memory (RAM).",
-        "compatability": [is_intel_compatible],
-        "routing": {"function": get_intel_power},
-    },
-    {
-        "name": "cpu_count_adjusted_average_load",
-        "description": "Measures the average load on the system for the past 5, 10, 15 minutes divided by number of CPUs (wrapper for psutil method). As fraction (percentage needs multiplication by 100)",
-        "compatability": [all_compatible],
-        "routing": {"function": get_cpu_count_adjusted_load_avg},
-    },
-    {
-        "name": "cpu_freq",
-        "description": "Get cpu frequency including realtime in MHz.",
-        "compatability": [is_linux, is_cpu_freq_compatible],
-        "routing": {"function": get_cpu_freq},
-    },
-    {
-        "name": "realtime_carbon_intensity",
-        "description": "If available, the realtime carbon intensity in the region.",
-        "compatability": [is_capable_realtime_carbon_intensity],
-        "routing": {"function": get_realtime_carbon},
-    },
-    {
-        "name": "disk_write_speed",
-        "description": "The write speed to the disk estimated over .5 seconds.",
-        "compatability": [all_compatible],
-        "routing": {"function": measure_disk_speed_at_dir},
-    },
-]
+    INITIAL_INFO = [
+        {
+            "name": "python_package_info",
+            "description": "Python package info.",
+            "compatability": [all_compatible],
+            "routing": {"function": get_python_packages_and_versions},
+        },
+        {
+            "name": "cpu_info",
+            "description": "CPU hardware information.",
+            "compatability": [all_compatible],
+            "routing": {"function": get_my_cpu_info},
+        },
+        {
+            "name": "experiment_start",
+            "description": "Start time of experiment.",
+            "compatability": [all_compatible],
+            "routing": {"function": get_time_now},
+        },
+        {
+            "name": "gpu_info",
+            "description": "GPU hardware information.",
+            "compatability": [is_nvidia_compatible, is_linux],
+            "routing": {"function": get_gpu_info},
+        },
+        {
+            "name": "experiment_impact_tracker_version",
+            "description": "Version of experiment-impact-tracker framework.",
+            "compatability": [all_compatible],
+            "routing": {"function": get_version_number},
+        },
+        {
+            "name": "region",
+            "description": "The region we determine this experiment to be run in.",
+            "compatability": [all_compatible],
+            # "routing": {"function": lambda: get_current_region_info_cached()[0]},
+
+            #A wrapper for selecting current vs specific region_info
+            "routing": {"function": lambda: get_region_info(REGION_COORDS)[0]}, 
+        },
+        {
+            "name": "region_carbon_intensity_estimate",
+            "description": "The average carbon intensity estimated for the region this experiment is in.",
+            "compatability": [all_compatible],
+            # "routing": {"function": lambda: get_current_region_info_cached()[1]},
+
+            #A wrapper for selecting current vs specific region_info
+            "routing": {"function": lambda: get_region_info(REGION_COORDS)[1]},
+        },
+    ]
+
+    return INITIAL_INFO
+
+def get_data_headers():
+
+    DATA_HEADERS = [
+        {
+            "name": "timestamp",
+            "description": "Time at which sample was drawn based on local machine time in timestamp format.",
+            "compatability": [all_compatible],
+            "routing": {"function": get_timestamp},
+        },
+        {
+            "name": "rapl_power_draw_absolute",
+            "description": "The absolute power draw reading read from an Intel RAPL package. This is in terms of Watts across the entire machine.",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "rapl_estimated_attributable_power_draw",
+            "description": "This is the estimated attributable power draw to this process and all child processes based on power draw reading read from an Intel RAPL package. This is calculated as (watts used by cpu) * (relative cpu percentage used) + (watts used by dram) * (relative dram percentage used) + (watts used by other package elements) * (relative cpu percentage used).",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "nvidia_draw_absolute",
+            "description": "This is the absolute power draw of all accessible NVIDIA GPUs on the system (as long as the main process or any child process lives on the GPU). Calculated as sum across all GPUs.",
+            "compatability": [is_nvidia_compatible, is_linux],
+            "routing": {"function": get_nvidia_gpu_power},
+        },
+        {
+            "name": "nvidia_estimated_attributable_power_draw",
+            "description": "This is the estimated attributable power draw of all accessible NVIDIA GPUs on the system (as long as the main process or any child process lives on the GPU). Calculated as the sum per gpu of (absolute power draw per gpu) * (relative process percent utilization of gpu)",
+            "compatability": [is_nvidia_compatible, is_linux],
+            "routing": {"function": get_nvidia_gpu_power},
+        },
+        {
+            "name": "cpu_time_seconds",
+            "description": "This is the total CPU time used so far by the program in seconds.",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "average_gpu_estimated_utilization_absolute",
+            "description": "This is the absolute utilization of the GPUs by the main process and all child processes. Returns an average result across several trials of nvidia-smi pmon -c 10. Averaged across GPUs. Using .05 to indicate 5%.",
+            "compatability": [is_nvidia_compatible, is_linux],
+            "routing": {"function": get_nvidia_gpu_power},
+        },
+        {
+            "name": "average_gpu_estimated_utilization_relative",
+            "description": "This is the relative utilization of the GPUs by the main process and all child processes. Returns an average result across several trials of nvidia-smi pmon -c 10 and the percentage that this process and all child process utilize for the gpu.  Averaged across GPUs. Using .05 to indicate 5%. ",
+            "compatability": [is_nvidia_compatible, is_linux],
+            "routing": {"function": get_nvidia_gpu_power},
+        },
+        {
+            "name": "average_relative_cpu_utilization",
+            "description": "This is the relative CPU utlization compared to the utilization of the whole system at that time. E.g., if the total system is using 50\% of the CPU power, but our program is only using 25\%, this will return .5.",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "absolute_cpu_utilization",
+            "description": "This is the relative CPU utlization compared to the utilization of the whole system at that time. E.g., if the total system is using 50\% of 4 CPUs, but our program is only using 25\% of 2 CPUs, this will return .5 (same as in top). There is no multiplier times the number of cores in this case as top does. ",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "per_gpu_performance_state",
+            "description": "A concatenated string which gives the performance state of every single GPU used by the main process or all child processes. Example formatting looks like <gpuid>::<performance state>. E.g., 0::P0",
+            "compatability": [is_nvidia_compatible, is_linux],
+            "routing": {"function": get_nvidia_gpu_power},
+        },
+        {
+            "name": "relative_mem_usage",
+            "description": "The percentage of all in-use ram this program is using.",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "absolute_mem_usage",
+            "description": "The amount of memory being used.",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "absolute_mem_percent_usage",
+            "description": "The amount of memory being used as an absolute percentage of total memory (RAM).",
+            "compatability": [is_intel_compatible],
+            "routing": {"function": get_intel_power},
+        },
+        {
+            "name": "cpu_count_adjusted_average_load",
+            "description": "Measures the average load on the system for the past 5, 10, 15 minutes divided by number of CPUs (wrapper for psutil method). As fraction (percentage needs multiplication by 100)",
+            "compatability": [all_compatible],
+            "routing": {"function": get_cpu_count_adjusted_load_avg},
+        },
+        {
+            "name": "cpu_freq",
+            "description": "Get cpu frequency including realtime in MHz.",
+            "compatability": [is_linux, is_cpu_freq_compatible],
+            "routing": {"function": get_cpu_freq},
+        },
+        {
+            "name": "realtime_carbon_intensity",
+            "description": "If available, the realtime carbon intensity in the region.",
+            "compatability": [is_capable_realtime_carbon_intensity],
+            "routing": {"function": get_realtime_carbon},
+        },
+        {
+            "name": "disk_write_speed",
+            "description": "The write speed to the disk estimated over .5 seconds.",
+            "compatability": [all_compatible],
+            "routing": {"function": measure_disk_speed_at_dir},
+        },
+    ]
+    return DATA_HEADERS

--- a/experiment_impact_tracker/data_info_and_router.py
+++ b/experiment_impact_tracker/data_info_and_router.py
@@ -26,7 +26,7 @@ get_time_now = lambda *args, **kwargs: datetime.now()
 all_compatible = lambda *args, **kwargs: True
 
 # Replaced INITIAL_INFO AND DATA_HEADERS with a function wrapper
-def get_initial_info(REGION_COORDS=None): 
+def get_initial_info(region_coords=None): 
 
     INITIAL_INFO = [
         {
@@ -63,19 +63,17 @@ def get_initial_info(REGION_COORDS=None):
             "name": "region",
             "description": "The region we determine this experiment to be run in.",
             "compatability": [all_compatible],
-            # "routing": {"function": lambda: get_current_region_info_cached()[0]},
-
+            
             #A wrapper for selecting current vs specific region_info
-            "routing": {"function": lambda: get_region_info(REGION_COORDS)[0]}, 
+            "routing": {"function": lambda: get_region_info(region_coords)[0]}, 
         },
         {
             "name": "region_carbon_intensity_estimate",
             "description": "The average carbon intensity estimated for the region this experiment is in.",
             "compatability": [all_compatible],
-            # "routing": {"function": lambda: get_current_region_info_cached()[1]},
-
+            
             #A wrapper for selecting current vs specific region_info
-            "routing": {"function": lambda: get_region_info(REGION_COORDS)[1]},
+            "routing": {"function": lambda: get_region_info(region_coords)[1]},
         },
     ]
 

--- a/experiment_impact_tracker/emissions/constants.py
+++ b/experiment_impact_tracker/emissions/constants.py
@@ -46,8 +46,8 @@ def _load_zone_names():
         dict : the loaded json file
     """
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    with open(os.path.join(dir_path, "data/zone_names.json"), "rt") as f:
-        x = json.load(f)
+    with open(os.path.join(dir_path, "data/zone_names.json"), "rt", encoding='utf-8') as f:
+        x = json.load(f )
     return x
 
 

--- a/experiment_impact_tracker/emissions/get_region_metrics.py
+++ b/experiment_impact_tracker/emissions/get_region_metrics.py
@@ -42,6 +42,14 @@ def get_current_location():
 def get_current_region_info(*args, **kwargs):
     return get_zone_information_by_coords(get_current_location())
 
+### Added by nikhil153 to avoid error in get_current_region_info_cached on CC
+def get_region_info(region_coords=None):
+    ''' Wrapper func to grab zone info based on either specific lat-long coordinates or default current region
+    '''
+    if region_coords == None:
+        return get_current_region_info_cached()
+    else:
+        return get_zone_information_by_coords(region_coords)
 
 def get_zone_name_by_id(zone_id):
     zone = ZONE_NAMES["zoneShortName"][zone_id]

--- a/experiment_impact_tracker/emissions/get_region_metrics.py
+++ b/experiment_impact_tracker/emissions/get_region_metrics.py
@@ -46,6 +46,7 @@ def get_current_region_info(*args, **kwargs):
 def get_region_info(region_coords=None):
     ''' Wrapper func to grab zone info based on either specific lat-long coordinates or default current region
     '''
+    print('Emissions region coords: {}'.format(region_coords))
     if region_coords == None:
         return get_current_region_info_cached()
     else:

--- a/experiment_impact_tracker/emissions/get_region_metrics.py
+++ b/experiment_impact_tracker/emissions/get_region_metrics.py
@@ -42,11 +42,10 @@ def get_current_location():
 def get_current_region_info(*args, **kwargs):
     return get_zone_information_by_coords(get_current_location())
 
-### Added by nikhil153 to avoid error in get_current_region_info_cached on CC
+### Added by nikhil153 to avoid error in get_current_region_info_cached on offline clusters
 def get_region_info(region_coords=None):
     ''' Wrapper func to grab zone info based on either specific lat-long coordinates or default current region
     '''
-    print('Emissions region coords: {}'.format(region_coords))
     if region_coords == None:
         return get_current_region_info_cached()
     else:


### PR DESCRIPTION
@Breakend Here is a PR for the issue we discussed (#57). It provides an option to specify region coordinates (longitude and latitude) for the cluster location. In unspecified, it defaults to the original _ping the ipinfo.io_ approach. 

I am not entirely clear on why location is queried by both the gather_initial_info() and _sample_and_log_power() functions, but regardless I have updated both of these to use specified longitude and latitude of the region. 

Hope this helps! 