### PR TITLE
Fix error thrown by multiprocessing set_start_method

### DIFF
--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -290,7 +290,7 @@ class ImpactTracker(object):
         try:
             # the defaults for multiprocessing changed in python 3.8.
             # OS X multiprocessing starts processes with spawn instead of fork
-            multiprocessing.set_start_method("fork")
+            multiprocessing.set_start_method("spawn")
             self.p, self.queue = launch_power_monitor(
                 self.logdir, self.initial_info, self.logger
             )

--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -290,7 +290,7 @@ class ImpactTracker(object):
         try:
             # the defaults for multiprocessing changed in python 3.8.
             # OS X multiprocessing starts processes with spawn instead of fork
-            multiprocessing.set_start_method("spawn")
+            multiprocessing.set_start_method("fork", force=True)
             self.p, self.queue = launch_power_monitor(
                 self.logdir, self.initial_info, self.logger
             )


### PR DESCRIPTION
This PR addresses a bug in the multiprocessing logic for the compute tracker. Specifically, it addresses a RuntimeError caused by the multiprocessing `set_start_method`, which complains that 'context has already been set'.  To avoid this error, we set `force=True` when creating a new fork.