### PR TITLE
Pandas 2.0 fixes

### DIFF
--- a/experiment_impact_tracker/compute_tracker.py
+++ b/experiment_impact_tracker/compute_tracker.py
@@ -17,7 +17,10 @@ import numpy as np
 import pandas as pd
 import psutil
 import ujson as json
-from pandas.io.json import json_normalize
+try:
+    from pandas.io.json import json_normalize
+except ImportError:
+    from pandas import json_normalize
 
 from experiment_impact_tracker.cpu import rapl
 from experiment_impact_tracker.cpu.common import get_my_cpu_info

--- a/experiment_impact_tracker/data_interface.py
+++ b/experiment_impact_tracker/data_interface.py
@@ -34,7 +34,7 @@ from experiment_impact_tracker.stats import (get_average_treatment_effect,
                                              run_test)
 from experiment_impact_tracker.utils import gather_additional_info
 
-pd.set_option("display.max_colwidth", -1)
+pd.set_option("display.max_colwidth", None)
 
 
 def _gather_executive_summary(

--- a/experiment_impact_tracker/data_utils.py
+++ b/experiment_impact_tracker/data_utils.py
@@ -5,7 +5,11 @@ import zipfile
 from datetime import datetime
 
 import ujson as json
-from pandas.io.json import json_normalize
+
+try:
+    from pandas.io.json import json_normalize
+except ImportError:
+    from pandas import json_normalize
 
 BASE_LOG_PATH = "impacttracker/"
 DATAPATH = BASE_LOG_PATH + "data.json"

--- a/experiment_impact_tracker/emissions/rough_emissions_estimator.py
+++ b/experiment_impact_tracker/emissions/rough_emissions_estimator.py
@@ -41,7 +41,7 @@ class RoughEmissionsEstimator(object):
         carbonIntensity = zone_info['carbonIntensity']
         carbonIntensity_source = zone_info['_source']
 
-        gpu_kWh = kWh = float(self.gpu_vals['tdp']) * self.gpu_utilization_factor * (self.experiment_length_seconds /
+        gpu_kWh = kWh = float(self.gpu_vals['tdp'].iloc[0]) * self.gpu_utilization_factor * (self.experiment_length_seconds /
                                                                                  3600.)\
                  / \
               1000.
@@ -81,9 +81,9 @@ class RoughEmissionsEstimator(object):
         lower = ssc["16.7%"]
         upper = ssc["83.3%"]
 
-        median_carbon_cost = (kg_carbon / 1000.) * float(median)
-        upper_carbon_cost = (kg_carbon / 1000.) * float(upper)
-        lower_carbon_cost = (kg_carbon / 1000.) * float(lower)
+        median_carbon_cost = (kg_carbon / 1000.) * float(median.iloc[0])
+        upper_carbon_cost = (kg_carbon / 1000.) * float(upper.iloc[0])
+        lower_carbon_cost = (kg_carbon / 1000.) * float(lower.iloc[0])
 
         bibtex_nature = """
         @article{ricke2018country,

--- a/scripts/create-compute-appendix
+++ b/scripts/create-compute-appendix
@@ -25,7 +25,7 @@ from experiment_impact_tracker.emissions.get_region_metrics import \
     get_zone_name_by_id
 from experiment_impact_tracker.utils import gather_additional_info
 
-pd.set_option('display.max_colwidth', -1)
+pd.set_option('display.max_colwidth', None)
 
 
 def _gather_executive_summary(aggregated_info, executive_summary_variables, experiment_set_names, all_points=False):

--- a/scripts/generate-carbon-impact-statement
+++ b/scripts/generate-carbon-impact-statement
@@ -35,7 +35,7 @@ from experiment_impact_tracker.stats import (get_average_treatment_effect,
                                              run_test)
 from experiment_impact_tracker.utils import gather_additional_info
 
-pd.set_option('display.max_colwidth', -1)
+pd.set_option('display.max_colwidth', None)
 
 
 


### PR DESCRIPTION
Updating to Pandas 2.0 resulted in a few minor errors, and this PR should handle the issues I encountered. Fixes include

- `pandas.io.json.json_normalize` is now located in `pandas.json_normalize`
- `pandas.set_option('display.max_colwidth', -1)` does not accept negative values, updated to pass `None` instead 
- casting Series/DataFrame entries to float is deprecated, updated to use `float(df.iloc[0])`