### PR TITLE
fix power_readings tag ambuguity in nvidia-smi xml

### DIFF
--- a/experiment_impact_tracker/gpu/nvidia.py
+++ b/experiment_impact_tracker/gpu/nvidia.py
@@ -189,7 +189,7 @@ def get_nvidia_gpu_power(pid_list, logger=None, **kwargs):
         gpu_data["utilization"] = {"gpu_util": gpu_util, "memory_util": memory_util}
 
         # get power
-        power_readings = gpu.findall("power_readings")[0]
+        power_readings = gpu.findall("power_readings")[0] if gpu.findall("power_readings") else gpu.findall("gpu_power_readings")[0]
         power_draw = power_readings.findall("power_draw")[0].text
 
         gpu_data["power_readings"] = {"power_draw": power_draw}


### PR DESCRIPTION
This is the output snippet from `nvidia-smi -x -q` with driver version 525.125.06
```
...
<power_readings>
	<power_state>P5</power_state>
	<power_management>Supported</power_management>
	<power_draw>37.29 W</power_draw>
	<power_limit>420.00 W</power_limit>
	<default_power_limit>420.00 W</default_power_limit>
	<enforced_power_limit>420.00 W</enforced_power_limit>
	<min_power_limit>100.00 W</min_power_limit>
	<max_power_limit>450.00 W</max_power_limit>
</power_readings>
...
```
Not sure starting from which version of driver that they slightly changed the xml document schema to this (this was generated with 535.104.05)
```
...
<gpu_power_readings>
	<power_state>P8</power_state>
	<power_draw>17.89 W</power_draw>
	<current_power_limit>220.00 W</current_power_limit>
	<requested_power_limit>220.00 W</requested_power_limit>
	<default_power_limit>220.00 W</default_power_limit>
	<min_power_limit>100.00 W</min_power_limit>
	<max_power_limit>240.00 W</max_power_limit>
</gpu_power_readings>
<module_power_readings>
	<power_state>P8</power_state>
	<power_draw>N/A</power_draw>
	<current_power_limit>N/A</current_power_limit>
	<requested_power_limit>N/A</requested_power_limit>
	<default_power_limit>N/A</default_power_limit>
	<min_power_limit>N/A</min_power_limit>
	<max_power_limit>N/A</max_power_limit>
</module_power_readings>
...
```
The xml extraction part in `gpu/nvidia` which tries to get power draw from `nvidia-smi` needs to be changed from locating the `"power_readings"` tag to the `"gpu_power_readings"` tag to support newer version of nvidia driver.